### PR TITLE
fixes #4 : Les boutons diviser et multiplier affichent l'opérateur associé 

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -26,12 +26,12 @@
          <button type="button" class="btn" onclick="appendToDisplay('7')">7</button>
          <button type="button" class="btn" onclick="appendToDisplay('8')">88</button>
          <button type="button" class="btn" onclick="appendToDisplay('9')">9</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('*')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('*')">*</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('0')">0</button>
          <button type="button" class="btn" onclick="clearDisplay()">C</button>
          <button type="submit" class="btn operator">=</button>
-         <button type="button" class="btn operator" onclick="appendToDisplay('/')"></button>
+         <button type="button" class="btn operator" onclick="appendToDisplay('/')">/</button>
       </div>
    </form>
 </div>


### PR DESCRIPTION
Cette PR ajoute le contenu textuel des opérateurs dans les balises HTML de l'interface utilisateur pour la multiplication (*) et la division (/), qui étaient vides précédemment.