### PR TITLE
fixes #5 : Les boutons 2 et 8 sont affichés correctement ('2' au lieu…

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -14,7 +14,7 @@
 
       <div class="buttons">
          <button type="button" class="btn" onclick="appendToDisplay('1')">1</button>
-         <button type="button" class="btn" onclick="appendToDisplay('2')">02</button>
+         <button type="button" class="btn" onclick="appendToDisplay('2')">2</button>
          <button type="button" class="btn" onclick="appendToDisplay('3')">3</button>
          <button type="button" class="btn operator" onclick="appendToDisplay('+')">+</button>
 
@@ -24,7 +24,7 @@
          <button type="button" class="btn operator" onclick="appendToDisplay('-')">-</button>
 
          <button type="button" class="btn" onclick="appendToDisplay('7')">7</button>
-         <button type="button" class="btn" onclick="appendToDisplay('8')">88</button>
+         <button type="button" class="btn" onclick="appendToDisplay('8')">8</button>
          <button type="button" class="btn" onclick="appendToDisplay('9')">9</button>
          <button type="button" class="btn operator" onclick="appendToDisplay('*')"></button>
 


### PR DESCRIPTION
Cette PR corrige des erreurs dans le contenu textuel des boutons du pavé numérique qui n'affichaient pas correctement le contenu des boutons '2' et '8'